### PR TITLE
Change fd_set variable name to fdset

### DIFF
--- a/doc/version.texi
+++ b/doc/version.texi
@@ -1,4 +1,4 @@
-@set UPDATED 3 June 2019
-@set UPDATED-MONTH June 2019
+@set UPDATED 11 October 2021
+@set UPDATED-MONTH October 2021
 @set EDITION 1.1dev
 @set VERSION 1.1dev

--- a/src/cbui.cpp
+++ b/src/cbui.cpp
@@ -200,16 +200,16 @@ bool CbUI::isDataReady()
     if (fd<=0) return false;
 
     struct timeval tv;
-    fd_set  fd_set;
+    fd_set  fdset;
 
     // use select to see if there the port is ready
     tv.tv_sec  = 0;
     tv.tv_usec = 1;
 
-    FD_ZERO(&fd_set);
-    FD_SET(fd, &fd_set);
+    FD_ZERO(&fdset);
+    FD_SET(fd, &fdset);
 
-    if (select(FD_SETSIZE, &fd_set, 0, 0, &tv)==0) return false;
+    if (select(FD_SETSIZE, &fdset, 0, 0, &tv)==0) return false;
 
     // now check the IO controller to see if there are any bytes ready
     // if not, the port is disconnected.

--- a/src/wiz_socket.cpp
+++ b/src/wiz_socket.cpp
@@ -783,21 +783,21 @@ bool wiz_socket::isDisconnected()
     if (!fd) return true;   // socket is closed
 
     struct timeval tv;
-    fd_set  fd_set;
+    fd_set  fdset;
 
     // use select to see if there the port is ready - a disconnected
     // port will return true;
     tv.tv_sec  = 0;
     tv.tv_usec = 1;
 
-    FD_ZERO(&fd_set);
+    FD_ZERO(&fdset);
     if (tcpfd) {
-        FD_SET(tcpfd, &fd_set);
+        FD_SET(tcpfd, &fdset);
     } else {
-        FD_SET(fd, &fd_set);
+        FD_SET(fd, &fdset);
     }
 
-    if (select(FD_SETSIZE, &fd_set, 0, 0, &tv)==0) return false;
+    if (select(FD_SETSIZE, &fdset, 0, 0, &tv)==0) return false;
 
     // now check the IO controller to see if there are any bytes ready
     // if not, the port is disconnected.
@@ -828,18 +828,18 @@ bool wiz_socket::isDataReady()
     if (descriptor<=0) return false;
 
     struct timeval tv;
-    fd_set  fd_set;
+    fd_set  fdset;
 
     // use select to see if there the port is ready - a disconnected
     // port will return true;
     tv.tv_sec  = 0;
     tv.tv_usec = 1;
 
-    FD_ZERO(&fd_set);
-    FD_SET(fd, &fd_set);
-    if (descriptor!=fd) FD_SET(descriptor,&fd_set);
+    FD_ZERO(&fdset);
+    FD_SET(fd, &fdset);
+    if (descriptor!=fd) FD_SET(descriptor,&fdset);
 
-    if (select(FD_SETSIZE, &fd_set, 0, 0, &tv)==0) return false;
+    if (select(FD_SETSIZE, &fdset, 0, 0, &tv)==0) return false;
 
     // now check the IO controller to see if there are any bytes ready
     // if not, the port is disconnected.
@@ -856,15 +856,15 @@ bool wiz_socket::isDataReady()
 */
 bool wiz_socket::isConnectionAvailable() {
     struct timeval tv;
-    fd_set  fd_set;
+    fd_set  fdset;
 
     // use select to see if there the port is ready - a disconnected
     // port will return true;
     tv.tv_sec  = 0;
     tv.tv_usec = 1;
 
-    FD_ZERO(&fd_set);
-    FD_SET(fd, &fd_set);
+    FD_ZERO(&fdset);
+    FD_SET(fd, &fdset);
 
-    return (select(FD_SETSIZE, &fd_set, 0, 0, &tv)>0);
+    return (select(FD_SETSIZE, &fdset, 0, 0, &tv)>0);
 }


### PR DESCRIPTION
Four functions in `wiz_socket.cpp` and `cbui.cpp` instantiated an `fd_set` struct with a variable name `fd_set`. This led to compiler errors on Ubuntu 18.04 for ARM64 architecture, including Macs with the M1 processor. This PR changes the local variable name to `fdset` and resolves compiler errors.